### PR TITLE
Allow for error handler to be passed as parameter

### DIFF
--- a/lib/concat.js
+++ b/lib/concat.js
@@ -2,28 +2,28 @@
   module.exports = concat
 
   var fs = require('fs')
-  function concat(files, target, done, errFunction){
-    validateInputs(files, target, done, errFunction)
+  function concat(files, target, onSuccess, onError){
+    validateInputs(files, target, onSuccess, onError)
     var writeStream = fs.createWriteStream(target, {flags: 'a'})
-    writeFiles(files.reverse(), writeStream, done, errFunction)
+    writeFiles(files.reverse(), writeStream, onSuccess, onError)
   }
 
-  function writeFiles(files, writeStream, callback, errFunction){
+  function writeFiles(files, writeStream, onSuccess, onError){
     if(files.length){
       var currentFile = files.pop()
       var readStream = fs.createReadStream(currentFile)
       readStream.pipe(writeStream, { end: false })
-      readStream.on('error', errFunction)
+      readStream.on('error', onError)
       readStream.on('end', function onReadEnd(){
-        writeFiles(files, writeStream, callback, errFunction)
+        writeFiles(files, writeStream, onSuccess, onError)
       })
     } else {
       writeStream.end();
-      callback()
+      onSuccess()
     }
   }
 
-  function validateInputs(files, target, done, errFunction){
+  function validateInputs(files, target, onSuccess, onError){
     if(!(files instanceof Array)){
       throw new Error('Expected array but got:', files)
     }
@@ -35,8 +35,8 @@
     if(target.constructor !== String || target.length === 0){
       throw new Error('Expected string destination but got:', target)
     }
-    if(typeof done !== 'function' && typeof errFunction !== 'function'){
-      throw new Error('Expected callback and errFunction to be functions!')
+    if(typeof onSuccess !== 'function' && typeof onError !== 'function'){
+      throw new Error('Expected onSuccess and onError to be functions!')
     }
   }
 })()

--- a/lib/concat.js
+++ b/lib/concat.js
@@ -2,20 +2,20 @@
   module.exports = concat
 
   var fs = require('fs')
-  function concat(files, target, done){
-    validateInputs(files, target, done)
+  function concat(files, target, done, errFunction){
+    validateInputs(files, target, done, errFunction)
     var writeStream = fs.createWriteStream(target, {flags: 'a'})
-    writeFiles(files.reverse(), writeStream, done)
+    writeFiles(files.reverse(), writeStream, done, errFunction)
   }
 
-  function writeFiles(files, writeStream, callback){
+  function writeFiles(files, writeStream, callback, errFunction){
     if(files.length){
       var currentFile = files.pop()
       var readStream = fs.createReadStream(currentFile)
       readStream.pipe(writeStream, { end: false })
-      readStream.on('error', onError)
+      readStream.on('error', errFunction)
       readStream.on('end', function onReadEnd(){
-        writeFiles(files, writeStream, callback)
+        writeFiles(files, writeStream, callback, errFunction)
       })
     } else {
       writeStream.end();
@@ -23,7 +23,7 @@
     }
   }
 
-  function validateInputs(files, target, done){
+  function validateInputs(files, target, done, errFunction){
     if(!(files instanceof Array)){
       throw new Error('Expected array but got:', files)
     }
@@ -35,11 +35,8 @@
     if(target.constructor !== String || target.length === 0){
       throw new Error('Expected string destination but got:', target)
     }
-    if(typeof done !== 'function'){
-      throw new Error('Expected callback to bea function but got:', done)
+    if(typeof done !== 'function' && typeof errFunction !== 'function'){
+      throw new Error('Expected callback and errFunction to be functions!')
     }
-  }
-  function onError(err) {
-    throw err
   }
 })()


### PR DESCRIPTION
So that errors can be properly handled in cases like Promises etc.

Example: 

```
return new Promise(function(resolvePromise, rejectPromise) {
     fileConcat(items, fileName, 
     function() { resolvePromise(); }), 
     function() { rejectPromise(); })
});
```